### PR TITLE
Implement HTTPS support as well as ability to pass arbitrary curl options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to `ntlm-soap-client` will be documented in this file.
 
+## Unreleased 
+
+### Added
+- added support for HTTPS streams
+- added support for passing arbitrary CURL options
+
+
 ## Version 1.1.0 - 2016-11-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,11 +17,18 @@ $ composer require matejsvajger/ntlm-soap-client
 ## Usage
 
 ``` php
-$url = 'URL_TO_WEBSERVICE_WSDL';
+$url = 'URL_TO_WEBSERVICE_WSDL';  // http and https are both supported
 $config = new matejsvajger\NTLMSoap\Common\NTLMConfig([
     'domain'   => 'domain',
     'username' => 'username',
-    'password' => 'password'
+    'password' => 'password',
+
+    // optionally pass curl options to be used
+    // for example, to disable SSL verification when using self-signed certs
+    'curlOptions' => array(
+        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYHOST => false
+    )
 ]);
 
 $client = new matejsvajger\NTLMSoap\Client($url, $config);

--- a/src/NTLMSoap/Common/NTLMConfig.php
+++ b/src/NTLMSoap/Common/NTLMConfig.php
@@ -61,6 +61,14 @@ class NTLMConfig implements \Serializable, \Iterator
         }
     }
 
+    public static function getCurlOptions()
+    {
+	if (isset($GLOBALS['NTLMClientCurlOptions'])) {
+	    return $GLOBALS['NTLMClientCurlOptions'];
+	}
+	return array();
+    }
+
     public function __set($param, $value)
     {
         $this->parameters[$param] = $value;

--- a/src/NTLMSoap/Model/BaseClient.php
+++ b/src/NTLMSoap/Model/BaseClient.php
@@ -28,19 +28,20 @@ class BaseClient extends \SoapClient
         $this->wdsl = $wdsl;
         $this->config = $config;
 
-        $wrapperExists = in_array("http", stream_get_wrappers());
+        $scheme = parse_url($wdsl, PHP_URL_SCHEME); // we expect 'http' or 'https'
+        $wrapperExists = in_array($scheme, stream_get_wrappers());
         if ($wrapperExists) {
-            stream_wrapper_unregister('http');
+            stream_wrapper_unregister($scheme);
         }
 
         //- Replace HTTP Stream with NTLMStream for authentication headers.
-        stream_wrapper_register('http', 'matejsvajger\NTLMSoap\Model\Stream\NTLMStream');
+        stream_wrapper_register($scheme, 'matejsvajger\NTLMSoap\Model\Stream\NTLMStream');
 
         parent::__construct($wdsl, $options);
 
         //- Restore http wrapper - further requests handled via cURL
         if ($wrapperExists) {
-            stream_wrapper_restore('http');
+            stream_wrapper_restore($scheme);
         }
     }
 

--- a/src/NTLMSoap/Model/Stream/NTLMStream.php
+++ b/src/NTLMSoap/Model/Stream/NTLMStream.php
@@ -142,6 +142,9 @@ class NTLMStream
         curl_setopt($this->ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         curl_setopt($this->ch, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
         curl_setopt($this->ch, CURLOPT_USERPWD, $auth);
+        foreach (NTLMConfig::getCurlOptions() as $option => $value) {
+            curl_setopt($this->ch, $option, $value);
+        }
         $this->buffer = curl_exec($this->ch);
         $this->pos = 0;
     }

--- a/src/NTLMSoap/Model/Traits/NTLMRequest.php
+++ b/src/NTLMSoap/Model/Traits/NTLMRequest.php
@@ -38,7 +38,9 @@ trait NTLMRequest
         curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
         curl_setopt($ch, CURLOPT_USERPWD, $auth);
-
+        foreach (NTLMConfig::getCurlOptions() as $option => $value) {
+            curl_setopt($ch, $option, $value);
+        }
         $response = curl_exec($ch);
 
         return $response;


### PR DESCRIPTION
I have added support for HTTPS streams as well as passing additional options to curl.

It is sometimes necessary to pass additional curl options, for example to connect to a service which uses a self-signed certificate.  This lets users pass these options without modifying the code.

